### PR TITLE
Add backend server and venues listing page

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,25 @@
 # VenueHub
+
+Aplicação para cadastro e consulta de locais para eventos. A interface está localizada em `index.html` e demais páginas dentro da pasta `src/pages`.
+
+## Backend
+
+Foi adicionado um backend simples usando [Express](https://expressjs.com/) para persistir dados no arquivo `db.json`.
+
+### Como iniciar
+
+1. Instale as dependências:
+   ```bash
+   npm install
+   ```
+2. Inicie o servidor:
+   ```bash
+   npm start
+   ```
+   O servidor será executado em `http://localhost:3000`.
+
+## Novas Páginas
+
+- **`src/pages/locais.html`** – lista todos os locais cadastrados no sistema.
+
+Para visualizar, com o servidor em execução, abra `src/pages/locais.html` em seu navegador.

--- a/index.html
+++ b/index.html
@@ -23,6 +23,7 @@
         <nav class="nav justify-content-center">
           <div class="d-flex flex-wrap gap-3 justify-content-center">
             <a href="./src/pages/anuncieseulocal.html">Anuncie seu Local</a>
+            <a href="./src/pages/locais.html">Locais</a>
             <a href="./src/pages/faleconosco.html">Fale Conosco</a>
             <a href="./src/pages/quemsomos.html">Quem somos</a>
             <a href="./src/pages/login.html" class="login"><img src="/docs/images/login.png" alt="imagem">Login</a>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "venuehub",
+  "version": "1.0.0",
+  "description": "Backend simples para o VenueHub",
+  "main": "server.js",
+  "scripts": {
+    "start": "node server.js"
+  },
+  "dependencies": {
+    "express": "^4.18.2"
+  }
+}

--- a/server.js
+++ b/server.js
@@ -1,0 +1,40 @@
+const express = require('express');
+const fs = require('fs');
+const path = require('path');
+
+const app = express();
+const PORT = 3000;
+
+app.use(express.json());
+app.use(express.static(path.join(__dirname)));
+
+function readDB() {
+  const data = fs.readFileSync(path.join(__dirname, 'db.json'), 'utf-8');
+  return JSON.parse(data);
+}
+
+function writeDB(db) {
+  fs.writeFileSync(path.join(__dirname, 'db.json'), JSON.stringify(db, null, 2));
+}
+
+app.get('/usuarios', (req, res) => {
+  const db = readDB();
+  res.json(db.usuarios);
+});
+
+app.post('/usuarios', (req, res) => {
+  const db = readDB();
+  const novo = { id: Date.now().toString(), ...req.body };
+  db.usuarios.push(novo);
+  writeDB(db);
+  res.json(novo);
+});
+
+app.get('/locais', (req, res) => {
+  const db = readDB();
+  res.json(db.locais);
+});
+
+app.listen(PORT, () => {
+  console.log(`Servidor rodando na porta ${PORT}`);
+});

--- a/src/css/locais.css
+++ b/src/css/locais.css
@@ -1,0 +1,41 @@
+body {
+  font-family: 'Inter', sans-serif;
+  margin: 0;
+  padding: 0;
+}
+
+.container {
+  max-width: 900px;
+  margin: 0 auto;
+  padding: 20px;
+}
+
+.lista-locais {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(250px, 1fr));
+  gap: 20px;
+}
+
+.local-card {
+  border: 1px solid #ddd;
+  border-radius: 8px;
+  padding: 10px;
+  text-align: center;
+}
+
+.local-card img {
+  width: 100%;
+  height: 150px;
+  object-fit: cover;
+  border-radius: 4px;
+}
+
+.local-card h3 {
+  margin: 10px 0 5px;
+  font-size: 1.1rem;
+}
+
+.local-card a {
+  color: #007bff;
+  text-decoration: none;
+}

--- a/src/js/locais.js
+++ b/src/js/locais.js
@@ -1,0 +1,30 @@
+import { buscarLocais } from './api.js';
+
+document.addEventListener('DOMContentLoaded', async () => {
+  const container = document.getElementById('lista-locais');
+  container.innerHTML = '<p>Carregando...</p>';
+
+  try {
+    const locais = await buscarLocais();
+    if(locais.length === 0) {
+      container.innerHTML = '<p>Nenhum local cadastrado.</p>';
+      return;
+    }
+
+    container.innerHTML = '';
+    locais.forEach(l => {
+      const div = document.createElement('div');
+      div.className = 'local-card';
+      div.innerHTML = `
+        <img src="${l.imagem}" alt="${l.nome}">
+        <h3>${l.nome}</h3>
+        <p>${l.bairro} - ${l.localidade}</p>
+        <a href="detalhes.html?id=${l.id}">Ver detalhes</a>
+      `;
+      container.appendChild(div);
+    });
+  } catch (err) {
+    container.innerHTML = '<p>Erro ao carregar locais.</p>';
+    console.error(err);
+  }
+});

--- a/src/pages/locais.html
+++ b/src/pages/locais.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="pt-br">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Locais Cadastrados | VenueHub</title>
+  <link rel="stylesheet" href="../css/locais.css">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet">
+</head>
+<body>
+  <header class="header">
+    <div class="container">
+      <div class="logo">
+        <a href="../../index.html"><img src="../../docs/images/venue.png" alt="VenueHub Logo"></a>
+      </div>
+      <nav class="nav">
+        <a href="anuncieseulocal.html">Anuncie seu Local</a>
+        <a href="faleconosco.html">Fale Conosco</a>
+        <a href="quemsomos.html">Quem somos</a>
+        <a href="login.html">Login</a>
+      </nav>
+    </div>
+  </header>
+
+  <main class="container">
+    <h1>Todos os Locais</h1>
+    <div id="lista-locais" class="lista-locais"></div>
+  </main>
+
+  <script type="module" src="../js/locais.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- implement simple Express backend using db.json
- add package.json with start script
- create page `locais.html` to list all venues
- add supporting JS and CSS for venues page
- link venues page in `index.html`
- document backend usage in README

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `node server.js` *(fails: Cannot find module 'express')*

------
https://chatgpt.com/codex/tasks/task_e_6861aa193cec83319249da61d65adba6